### PR TITLE
feat(tool): add Toreva MCP

### DIFF
--- a/content/tools/toreva.md
+++ b/content/tools/toreva.md
@@ -6,56 +6,54 @@ category: framework
 icon: "\U0001F3AF"
 official: true
 score: 7.0
-tagline_en: User-controlled goals and non-custodial Solana execution for AI agents
-tagline_zh: 面向 AI agent 的用户可控目标与非托管 Solana 执行层
+tagline_en: Durable goals and governed plans for AI agents
+tagline_zh: 面向 AI agent 的持久目标与受控计划
 fetch:
-  github: toreva/gateway
+  github: toreva/kit
 summary_en: >-
-  Keep and hand off goals between agents, inspect strategies and receipts, and
-  request governed execution without giving the agent custody.
+  Turn an outcome and its constraints into a plan you can review, refine, and
+  reopen after the chat.
 summary_zh: >-
-  跨 agent 保存和交接目标，查看策略与回执，并在不把资产托管权交给 agent 的前提下请求受控执行。
+  将目标和约束转化为可审查、可完善，并可在聊天结束后重新打开的计划。
 ---
 
 ## Toreva
 
-Toreva is a user-controlled goal and execution layer for AI agents. It lets an
-agent persist and hand off goals, inspect plans and receipts, and request
-non-custodial Solana execution subject to the user's authority.
+Toreva is a hosted MCP connector for durable, user-controlled goals. Inside
+Claude, it turns an outcome and its constraints into a governed plan the person
+can review, refine, and reopen after the chat.
 
-> Toreva 是面向 AI agent 的用户可控目标与执行层。它支持跨 agent 保存和交接目标、查看计划与回执，并在用户授权下请求非托管 Solana 执行。
+> Toreva 是一个用于持久、用户可控目标的托管 MCP 连接器。它可在 Claude 中将目标和约束转化为用户可审查、完善并在聊天结束后重新打开的受控计划。
 
 ### Connect
 
 - Remote MCP URL: `https://gateway.toreva.com/mcp`
-- [Claude installation guide](https://toreva.com/connect-claude)
-- [Source code](https://github.com/toreva/gateway)
+- [Claude installation guide](https://toreva.com/connect-claude?utm_source=agentstore&utm_medium=directory&utm_campaign=first_real_goal&utm_content=toreva)
+- [Public kit](https://github.com/toreva/kit)
 - [Website](https://toreva.com)
 
 ### Representative actions
 
-- Create, list, inspect, refine, continue, and hand off durable goals
-- Compile intent and inspect plans, strategies, objects, and receipts
+- Turn a stated outcome and its constraints into a reviewable plan
+- List and reopen durable goals and plans after the chat
+- Inspect plans, objects, and receipts
+- Refine a goal with a versioned decision or rejection
 - Save blocked goals so another agent can resume them
 - Open protected views without placing secrets in the model context
 - Record decision-point outcomes and continue from the observed result
-- In a linked full session, request governed non-custodial execution
 
 ### Example prompts
 
-- “Keep this goal in Toreva and continue it next time.”
+- “Turn this outcome and its constraints into a Toreva plan.”
 - “Show my active Toreva goals and open the one about customer acquisition.”
 - “Refine this goal without changing its terminal.”
 - “Save this blocked goal so another agent can continue it.”
 - “Show the receipts for the work completed on this goal.”
-- “Inspect the available strategies before any transaction.”
-- “Prepare this action and show me what requires my authority.”
 - “Record what I did after the decision point.”
 
 ### Security and pricing
 
-Toreva is hosted as a remote MCP server and its gateway source is public. Read
-and setup tools are separated from money-moving tools; money-moving tools are
-not exposed in the initial access rung. Toreva is non-custodial and no money
-moves without linked user authority. Data operations are free; value
-transactions cost 2 bps.
+Toreva is hosted as a remote MCP server and requires OAuth. The initial
+connector rung exposes goal and planning tools only. It does not expose
+money-moving tools, and this listing does not represent financial execution as
+generally available.

--- a/content/tools/toreva.md
+++ b/content/tools/toreva.md
@@ -1,0 +1,61 @@
+---
+slug: toreva
+name: Toreva
+author: Toreva
+category: framework
+icon: "\U0001F3AF"
+official: true
+score: 7.0
+tagline_en: User-controlled goals and non-custodial Solana execution for AI agents
+tagline_zh: 面向 AI agent 的用户可控目标与非托管 Solana 执行层
+fetch:
+  github: toreva/gateway
+summary_en: >-
+  Keep and hand off goals between agents, inspect strategies and receipts, and
+  request governed execution without giving the agent custody.
+summary_zh: >-
+  跨 agent 保存和交接目标，查看策略与回执，并在不把资产托管权交给 agent 的前提下请求受控执行。
+---
+
+## Toreva
+
+Toreva is a user-controlled goal and execution layer for AI agents. It lets an
+agent persist and hand off goals, inspect plans and receipts, and request
+non-custodial Solana execution subject to the user's authority.
+
+> Toreva 是面向 AI agent 的用户可控目标与执行层。它支持跨 agent 保存和交接目标、查看计划与回执，并在用户授权下请求非托管 Solana 执行。
+
+### Connect
+
+- Remote MCP URL: `https://gateway.toreva.com/mcp`
+- [Claude installation guide](https://toreva.com/connect-claude)
+- [Source code](https://github.com/toreva/gateway)
+- [Website](https://toreva.com)
+
+### Representative actions
+
+- Create, list, inspect, refine, continue, and hand off durable goals
+- Compile intent and inspect plans, strategies, objects, and receipts
+- Save blocked goals so another agent can resume them
+- Open protected views without placing secrets in the model context
+- Record decision-point outcomes and continue from the observed result
+- In a linked full session, request governed non-custodial execution
+
+### Example prompts
+
+- “Keep this goal in Toreva and continue it next time.”
+- “Show my active Toreva goals and open the one about customer acquisition.”
+- “Refine this goal without changing its terminal.”
+- “Save this blocked goal so another agent can continue it.”
+- “Show the receipts for the work completed on this goal.”
+- “Inspect the available strategies before any transaction.”
+- “Prepare this action and show me what requires my authority.”
+- “Record what I did after the decision point.”
+
+### Security and pricing
+
+Toreva is hosted as a remote MCP server and its gateway source is public. Read
+and setup tools are separated from money-moving tools; money-moving tools are
+not exposed in the initial access rung. Toreva is non-custodial and no money
+moves without linked user authority. Data operations are free; value
+transactions cost 2 bps.

--- a/src/lib/generated/tools.ts
+++ b/src/lib/generated/tools.ts
@@ -2090,8 +2090,8 @@ export const toolsFromMarkdown: Tool[] = [
     "name": "Toreva",
     "author": "Toreva",
     "tagline": {
-      "en": "User-controlled goals and non-custodial Solana execution for AI agents",
-      "zh": "面向 AI agent 的用户可控目标与非托管 Solana 执行层"
+      "en": "Durable goals and governed plans for AI agents",
+      "zh": "面向 AI agent 的持久目标与受控计划"
     },
     "category": "framework",
     "icon": "🎯",
@@ -2099,8 +2099,8 @@ export const toolsFromMarkdown: Tool[] = [
     "metrics": {},
     "score": 7,
     "summary": {
-      "en": "Keep and hand off goals between agents, inspect strategies and receipts, and request governed execution without giving the agent custody.",
-      "zh": "跨 agent 保存和交接目标，查看策略与回执，并在不把资产托管权交给 agent 的前提下请求受控执行。"
+      "en": "Turn an outcome and its constraints into a plan you can review, refine, and reopen after the chat.",
+      "zh": "将目标和约束转化为可审查、可完善，并可在聊天结束后重新打开的计划。"
     }
   },
   {

--- a/src/lib/generated/tools.ts
+++ b/src/lib/generated/tools.ts
@@ -2086,6 +2086,24 @@ export const toolsFromMarkdown: Tool[] = [
     }
   },
   {
+    "slug": "toreva",
+    "name": "Toreva",
+    "author": "Toreva",
+    "tagline": {
+      "en": "User-controlled goals and non-custodial Solana execution for AI agents",
+      "zh": "面向 AI agent 的用户可控目标与非托管 Solana 执行层"
+    },
+    "category": "framework",
+    "icon": "🎯",
+    "official": true,
+    "metrics": {},
+    "score": 7,
+    "summary": {
+      "en": "Keep and hand off goals between agents, inspect strategies and receipts, and request governed execution without giving the agent custody.",
+      "zh": "跨 agent 保存和交接目标，查看策略与回执，并在不把资产托管权交给 agent 的前提下请求受控执行。"
+    }
+  },
+  {
     "slug": "tradingview-mcp",
     "name": "TradingView MCP",
     "author": "atilaahmettaner",


### PR DESCRIPTION
Adds Toreva as an official framework entry.

Toreva is a hosted MCP connector for durable, user-controlled goals. In Claude, it turns an outcome and its constraints into a governed plan the person can review, refine, and reopen after the chat.

- Homepage: https://toreva.com
- Claude setup: https://toreva.com/connect-claude?utm_source=agentstore&utm_medium=directory&utm_campaign=first_real_goal&utm_content=toreva
- Public kit: https://github.com/toreva/kit
- Remote MCP endpoint: https://gateway.toreva.com/mcp

The initial connector rung exposes goal and planning tools only. It does not expose money-moving tools, and this submission does not claim financial execution or transaction pricing as generally available.

Verification:

- `npm run sync:tools`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

The repository's `npm run lint` command invokes the interactive first-run Next.js ESLint configuration prompt, so no lint configuration was generated or changed as part of this submission.
